### PR TITLE
Clarify purpose of rerun-if-changed in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,6 @@ fn main() {
         .unwrap();
     println!("cargo:rustc-link-search={}", out.display());
 
-    println!("cargo:rerun-if-changed=build.rs");
+    // Only re-run the build script when memory.x is changed, instead of at every build
     println!("cargo:rerun-if-changed=memory.x");
 }

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .unwrap();
     println!("cargo:rustc-link-search={}", out.display());
 
-    // Only re-run the build script when memory.x is changed, instead of at every build
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=memory.x");
 }


### PR DESCRIPTION
The current `build.rs` contains
```rust
    println!("cargo:rerun-if-changed=build.rs");
    println!("cargo:rerun-if-changed=memory.x");
```

This causes the build script to be re-run if (and *only if*) `build.rs` or `memory.x` change. The line for `build.rs` is redundant: the Cargo guide [says](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script) the build script is always rerun when `build.rs` changes, so we can drop that line.

The remaining line caused me a bit of confusion when adding other functionality to my project's build script, before I realised it tells Cargo to *only* rerun the build script when `memory.x` changes, as opposed to the default behaviour which is to rerun it on every build. The comment helps clarify the point of this line, so if users add other functionality to their build scripts it is hopefully easier to notice.