### PR TITLE
use LLD as the default linker

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,27 +1,56 @@
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
 ]
 
 [target.thumbv7m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  # the comments under `[target.thumbv6m-none-eabi]` also apply here
+  "-C", "link-arg=-Tlink.x",
+
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
 ]
 
 [target.thumbv7em-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  # the comments under `[target.thumbv6m-none-eabi]` also apply here
+  "-C", "link-arg=-Tlink.x",
+
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
 ]
 
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
-  "-C", "link-arg=-Wl,-Tlink.x",
-  "-C", "link-arg=-nostartfiles",
+  # the comments under `[target.thumbv6m-none-eabi]` also apply here
+  "-C", "link-arg=-Tlink.x",
+
+  # "-C", "linker=arm-none-eabi-ld",
+
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 //!
 //! - Nightly Rust toolchain newer than `nightly-2018-04-08`: `rustup default nightly`
 //! - Cargo `clone` subcommand: `cargo install cargo-clone`
-//! - ARM toolchain: `sudo apt-get install gcc-arm-none-eabi` (on Ubuntu)
 //! - GDB: `sudo apt-get install gdb-arm-none-eabi` (on Ubuntu)
 //! - OpenOCD: `sudo apt-get install OpenOCD` (on Ubuntu)
 //! - [Optional] Cargo `add` subcommand: `cargo install cargo-edit`
@@ -179,11 +178,13 @@
 //! ``` text
 //! $ cargo build
 //! Compiling demo v0.1.0 (file:///home/japaric/tmp/demo)
-//! error: linking with `arm-none-eabi-ld` failed: exit code: 1
+//! error: linking with `rust-lld` failed: exit code: 1
 //! |
-//! = note: "arm-none-eabi-gcc" "-L" (..)
+//! = note: "rust-lld" "-flavor" "gnu" "-L" (..)
 //! (..)
-//!           (..)/ld: region `FLASH' overflowed by XXX bytes
+//!  = note: rust-lld: error: section '.vector_table' will not fit in region 'FLASH': overflowed by X bytes
+//!          rust-lld: error: section '.vector_table' will not fit in region 'FLASH': overflowed by Y bytes
+//! (..)
 //! ```
 //!
 //! Solution: Specify your device memory layout in the `memory.x` linker script. See [Usage]


### PR DESCRIPTION
closes #39

I added instructions on how to switch to a different linker to .cargo/config but
I don't think that's too visible. Beginners are unlikely to look into that file
if they run into problems with the default linker. Any suggestions to improve
the visibility of that information?

Also, don't merge this until the default linker changes for the Cortex-M targets
on nightly as this relies on that change.

r? @rust-embedded/cortex-m