### PR TITLE
Default to extended-remote instead of remote mode

### DIFF
--- a/openocd.gdb
+++ b/openocd.gdb
@@ -1,4 +1,4 @@
-target remote :3333
+target extended-remote :3333
 
 # print demangled symbols
 set print asm-demangle on


### PR DESCRIPTION
Extended remote allows a lot more features like attaching and detaching and much more fine-grained execution options. If a gdbserver implementation supports it (and OpenOCD sure does) it should be preferred over `remote`.