### PR TITLE
Update rust version requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 To build embedded programs using this template you'll need:
 
-- Rust 1.30, 1.30-beta, nightly-2018-09-13 or a newer toolchain. e.g. `rustup
+- Rust 1.31, 1.30-beta, nightly-2018-09-13 or a newer toolchain. e.g. `rustup
   default beta`
-
-> **NOTE**: 1.30-beta is not out yet so you'll have to use the nightly channel
-> in the meantime.
 
 - The `cargo generate` subcommand. [Installation
   instructions](https://github.com/ashleygwilliams/cargo-generate#installation).


### PR DESCRIPTION
As Cargo.toml now includes edition = "2018", it won't build with rust 1.30-stable. 1.31-stable will be the first stable version to have the edition feature enabled. (See https://internals.rust-lang.org/t/rust-2018-release-schedule-and-extended-beta/8076 for details.)

At the same time, remove the remark about 1.30-beta not being out yet, as it's out by now.