### PR TITLE
Add example moving .bss data into custom memory

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -19,3 +19,16 @@ MEMORY
 /* This is required only on microcontrollers that store some configuration right
    after the vector table */
 /* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Example of putting non-initialized variables into custom RAM locations. */
+/* This assumes you have defined a region RAM2 above, and in the Rust
+   sources added the attribute `#[link_section = ".ram2bss"]` to the data
+   you want to place there. */
+/* Note that the section will not be zero-initialized by the runtime! */
+/* SECTIONS {
+     .ram2bss (NOLOAD) : ALIGN(4) {
+       *(.ram2bss);
+       . = ALIGN(4);
+     }
+   } INSERT AFTER .bss;
+*/

--- a/memory.x
+++ b/memory.x
@@ -29,6 +29,6 @@ MEMORY
      .ram2bss (NOLOAD) : ALIGN(4) {
        *(.ram2bss);
        . = ALIGN(4);
-     }
+     } > RAM2
    } INSERT AFTER .bss;
 */


### PR DESCRIPTION
We're using a STM32F429 and wanted to move stuff around in memory, notably put stack+data into CPU coupled memory, and put framebuffers for the integrated LCD controller into the normal SRAM.

Getting this right while not completely overriding the default `link.x` was quite tricky (especially finding the `INSERT AFTER` life-saver...) so I thought an example would not hurt here.

It should probably also be mentioned in other places (book/...)?