### PR TITLE
Update linker snippet in README to include stack start

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ MEMORY
   FLASH : ORIGIN = 0x08000000, LENGTH = 256K
   RAM : ORIGIN = 0x20000000, LENGTH = 40K
 }
+
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
 ```
 
 4. Build the template application or one of the examples.


### PR DESCRIPTION
Without this, my STM32F3 device generates a hard fault when zeroing the bss.