### PR TITLE
Adjust the default breakpoint name to match cortex-m-rt pull #144

### DIFF
--- a/openocd.gdb
+++ b/openocd.gdb
@@ -5,7 +5,7 @@ set print asm-demangle on
 
 # detect unhandled exceptions, hard faults and panics
 break DefaultHandler
-break UserHardFault
+break HardFault
 break rust_begin_unwind
 
 # *try* to stop at the user entry point (it might be gone due to inlining)


### PR DESCRIPTION
I noticed as I was going through the rust-embedded book that I was receiving the following warning when running the compiled code through GDB (via `cargo run`):

```
Function "UserHardFault" not defined.
```

It looks like [this was renamed](https://github.com/rust-embedded/cortex-m-rt/pull/144) and the template just didn't get updated. This PR just updates the associated default break point to match the change.