### PR TITLE
add openocd.gdb hint how to print panic immediatly

### DIFF
--- a/openocd.gdb
+++ b/openocd.gdb
@@ -10,6 +10,11 @@ set backtrace limit 32
 break DefaultHandler
 break HardFault
 break rust_begin_unwind
+# # run the next few lines so the panic message is printed immediately
+# # the number needs to be adjusted for your panic handler
+# commands $bpnum
+# next 4
+# end
 
 # *try* to stop at the user entry point (it might be gone due to inlining)
 break main


### PR DESCRIPTION
Just a little something to make the live for beginners easier.