### PR TITLE
Track launch.json, tasks.json, md & svd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@ Cargo.lock
 target/
 
 # editor files
-.vscode/
+.vscode/*
+!.vscode/*.md
+!.vscode/*.svd
+!.vscode/launch.json
+!.vscode/tasks.json


### PR DESCRIPTION
Ignoring the .vscode/ directory is good default behavior,
but it's probably best to track the files that define build tasks, debug
configs, documentation, and any system view description files.

The gitignore.io sample takes the same approach.
https://www.gitignore.io/api/visualstudiocode

> ```
> .vscode/*
> !.vscode/settings.json
> !.vscode/tasks.json
> !.vscode/launch.json
> !.vscode/extensions.json
> ```

The VS Code team is on the record as committing these files as well.

> We in the VS Code team share debug and task specific settings as well because we want our team to have the same set of debug targets and task targets for VS Code.

https://stackoverflow.com/a/32979933/3198973

Even people who vehemently argue that .vscode shouldn't be tracked, agree
that complex debug configs should be tracked and shared.

> The only .vscode that makes sense to include are complex launch configs for debugging.

https://stackoverflow.com/a/47668283/3198973