### PR TITLE
VS Code build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 !.vscode/*.svd
 !.vscode/launch.json
 !.vscode/tasks.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"rust-lang.rust",
+		"marus25.cortex-debug",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "name": "Debug (QEMU)",
             "servertype": "qemu",
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "build",
+            "preLaunchTask": "cargo build",
             "runToMain": true,
             "executable": "./target/thumbv7m-none-eabi/debug/{{project-name}}",
             /* Run `cargo build --example hello` and uncomment this line to run semi-hosting example */
@@ -27,7 +27,7 @@
             "name": "Debug (OpenOCD)",
             "servertype": "openocd",
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "build",
+            "preLaunchTask": "cargo build",
             "runToMain": true,
             "executable": "./target/thumbv7em-none-eabihf/debug/{{project-name}}",
             /* Run `cargo build --example itm` and uncomment this line to run itm example */

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
              * but we need to provide a label for it,
              * so we can invoke it from the debug launcher.
              */
-            "label": "build",
+            "label": "cargo build",
             "type": "cargo",
             "subcommand": "build",
             "problemMatcher": [
@@ -19,6 +19,42 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "label": "cargo build --release",
+            "type": "process",
+            "command": "cargo",
+            "args": ["build", "--release"],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "cargo build --examples",
+            "type": "process",
+            "command": "cargo",
+            "args": ["build","--examples"],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "cargo build --examples --release",
+            "type": "process",
+            "command": "cargo",
+            "args": ["build","--examples", "--release"],
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "cargo clean",
+            "type": "cargo",
+            "subcommand": "clean",
+            "group": "build"
         },
     ]
 }


### PR DESCRIPTION
Adds the following build tasks for VS Code:
- `clean`
- `--release`
- `--examples`
- `--examples --release`

It should be noted that `--examples` won't build successfully, because in general, you can't run `cargo build --examples` on projects generated from the quickstart.
It does trigger the correct behavior and I have tested these tasks on projects where it does build cleanly.

https://github.com/rubberduck203/stm32f3-discovery/blob/4933a160eee6ca53cc94c50d0470ea6e8ab03928/.vscode/tasks.json