### PR TITLE
Replace unidiomatic 'extern crate' to 'use x as _'

### DIFF
--- a/examples/allocator.rs
+++ b/examples/allocator.rs
@@ -15,7 +15,7 @@
 #![no_std]
 
 extern crate alloc;
-extern crate panic_halt;
+use panic_halt as _;
 
 use self::alloc::vec;
 use core::alloc::Layout;

--- a/examples/crash.rs
+++ b/examples/crash.rs
@@ -79,7 +79,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use core::ptr;
 

--- a/examples/device.rs
+++ b/examples/device.rs
@@ -26,7 +26,7 @@
 #![no_std]
 
 #[allow(unused_extern_crates)]
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m_rt::entry;

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::Peripherals;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -17,7 +17,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m::{iprintln, Peripherals};
 use cortex_m_rt::entry;

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -10,15 +10,15 @@
 // Pick one of these panic handlers:
 
 // `panic!` halts execution; the panic message is ignored
-extern crate panic_halt;
+use panic_halt as _;
 
 // Reports panic messages to the host stderr using semihosting
 // NOTE to use this you need to uncomment the `panic-semihosting` dependency in Cargo.toml
-// extern crate panic_semihosting;
+// use panic_semihosting as _;
 
 // Logs panic messages using the ITM (Instrumentation Trace Macrocell)
 // NOTE to use this you need to uncomment the `panic-itm` dependency in Cargo.toml
-// extern crate panic_itm;
+// use panic_itm as _;
 
 use cortex_m_rt::entry;
 

--- a/examples/test_on_host.rs
+++ b/examples/test_on_host.rs
@@ -23,10 +23,10 @@
 
 // pick a panicking behavior
 #[cfg(not(test))]
-extern crate panic_halt; // you can put a breakpoint on `rust_begin_unwind` to catch panics
-// extern crate panic_abort; // requires nightly
-// extern crate panic_itm; // logs messages over ITM; requires ITM support
-// extern crate panic_semihosting; // logs messages to the host stderr; requires a debugger
+use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
+// use panic_abort as _; // requires nightly
+// use panic_itm as _; // logs messages over ITM; requires ITM support
+// use panic_semihosting as _; // logs messages to the host stderr; requires a debugger
 
 use cortex_m::asm;
 use cortex_m_rt::entry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 // pick a panicking behavior
-extern crate panic_halt; // you can put a breakpoint on `rust_begin_unwind` to catch panics
-// extern crate panic_abort; // requires nightly
-// extern crate panic_itm; // logs messages over ITM; requires ITM support
-// extern crate panic_semihosting; // logs messages to the host stderr; requires a debugger
+use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
+// use panic_abort as _; // requires nightly
+// use panic_itm as _; // logs messages over ITM; requires ITM support
+// use panic_semihosting as _; // logs messages to the host stderr; requires a debugger
 
 use cortex_m::asm;
 use cortex_m_rt::entry;


### PR DESCRIPTION
Replacing unidiomatic `extern crate` in case of importing of panic_ crates.
The appropriate PR to https://github.com/rust-embedded/book/ is [here](https://github.com/rust-embedded/book/pull/248).