### PR TITLE
Fixes #99: Disambiguates VSCode Tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "name": "Debug (QEMU)",
             "servertype": "qemu",
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "cargo build",
+            "preLaunchTask": "Cargo Build (debug)",
             "runToMain": true,
             "executable": "./target/thumbv7m-none-eabi/debug/{{project-name}}",
             /* Run `cargo build --example hello` and uncomment this line to run semi-hosting example */
@@ -27,7 +27,7 @@
             "name": "Debug (OpenOCD)",
             "servertype": "openocd",
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "cargo build",
+            "preLaunchTask": "Cargo Build (debug)",
             "runToMain": true,
             "executable": "./target/thumbv7em-none-eabihf/debug/{{project-name}}",
             /* Run `cargo build --example itm` and uncomment this line to run itm example */

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
              * but we need to provide a label for it,
              * so we can invoke it from the debug launcher.
              */
-            "label": "cargo build",
+            "label": "Cargo Build (debug)",
             "type": "process",
             "command": "cargo",
             "args": ["build"],
@@ -22,7 +22,7 @@
             }
         },
         {
-            "label": "cargo build --release",
+            "label": "Cargo Build (release)",
             "type": "process",
             "command": "cargo",
             "args": ["build", "--release"],
@@ -32,7 +32,7 @@
             "group": "build"
         },
         {
-            "label": "cargo build --examples",
+            "label": "Cargo Build Examples (debug)",
             "type": "process",
             "command": "cargo",
             "args": ["build","--examples"],
@@ -42,7 +42,7 @@
             "group": "build"
         },
         {
-            "label": "cargo build --examples --release",
+            "label": "Cargo Build Examples (release)",
             "type": "process",
             "command": "cargo",
             "args": ["build","--examples", "--release"],
@@ -52,7 +52,7 @@
             "group": "build"
         },
         {
-            "label": "cargo clean",
+            "label": "Cargo Clean",
             "type": "process",
             "command": "cargo",
             "args": ["clean"],


### PR DESCRIPTION
Using the equivalent command line as the task name caused some confusion.
Users were under the impression that they could use any valid cargo command as a preLaunchTask in the launch configurations.