### PR TITLE
Update memory.x

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -3,7 +3,7 @@ MEMORY
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
   /* TODO Adjust these memory regions to match your device memory layout */
   /* These values correspond to the LM3S6965, one of the few devices QEMU can emulate */
-  FLASH : ORIGIN = 0x00000000, LENGTH = 256K
+  FLASH : ORIGIN = 0x08000000, LENGTH = 256K
   RAM : ORIGIN = 0x20000000, LENGTH = 64K
 }
 


### PR DESCRIPTION
Changes the default `FLASH : ORIGIN` to start at `0x08000000` for the LM3S6965 as the original value of `0x00000000` does not work when running `arm-none-eabi-gdb -q target/thumbv7em-none-eabihf/debug/examples/hello`

See #102 

Closes #102 