### PR TITLE
openocd.cfg: use the unified stlink.cfg configuration

### DIFF
--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,12 +1,5 @@
 # Sample OpenOCD configuration for the STM32F3DISCOVERY development board
 
-# Depending on the hardware revision you got you'll have to pick ONE of these
-# interfaces. At any time only one interface should be commented out.
-
-# Revision C (newer revision)
-source [find interface/stlink-v2-1.cfg]
-
-# Revision A and B (older revisions)
-# source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 source [find target/stm32f3x.cfg]


### PR DESCRIPTION
In newer versions of openocd, all the stlink-v* configuration files are deprecated, and just source stlink.cfg.