### PR TITLE
Recommend rust-analyzer vscode extension

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -11,13 +11,13 @@ This directory contains configurations for two platforms:
 If you have the `code` command in your path, you can run the following commands to install the necessary extensions.
 
 ```sh
-code --install-extension rust-lang.rust
+code --install-extension rust-lang.rust-analyzer
 code --install-extension marus25.cortex-debug
 ```
 
 Otherwise, you can use the Extensions view to search for and install them, or go directly to their marketplace pages and click the "Install" button.
 
-- [Rust Language Server (RLS)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
+- [Rust Language Server (rust-analyzer)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
 - [Cortex-Debug](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
 
 ## Use

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"rust-lang.rust",
+		"rust-lang.rust-analyzer",
 		"marus25.cortex-debug",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "servertype": "qemu",
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Cargo Build (debug)",
-            "runToMain": true,
+            "runToEntryPoint": "main",
             "executable": "./target/thumbv7m-none-eabi/debug/{{project-name}}",
             /* Run `cargo build --example hello` and uncomment this line to run semi-hosting example */
             //"executable": "./target/thumbv7m-none-eabi/debug/examples/hello",
@@ -28,7 +28,7 @@
             "servertype": "openocd",
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Cargo Build (debug)",
-            "runToMain": true,
+            "runToEntryPoint": "main",
             "executable": "./target/thumbv7em-none-eabihf/debug/{{project-name}}",
             /* Run `cargo build --example itm` and uncomment this line to run itm example */
             // "executable": "./target/thumbv7em-none-eabihf/debug/examples/itm",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
     /* 
-     * Requires the Rust Language Server (RLS) and Cortex-Debug extensions
-     * https://marketplace.visualstudio.com/items?itemName=rust-lang.rust
+     * Requires the Rust Language Server (rust-analyzer) and Cortex-Debug extensions
+     * https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer
      * https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug
      */
     "version": "0.2.0",


### PR DESCRIPTION
RLS and its extension have been deprecated as rust-analyzer has become the official language server for Rust.