### PR TITLE
Move link-arg setting from .cargo/config.toml to build.rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,27 +10,24 @@
 # runner = "gdb -q -x openocd.gdb"
 
 rustflags = [
-  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
-  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
-  "-C", "link-arg=--nmagic",
+  # Previously, the linker arguments --nmagic and -Tlink.x were set here.
+  # They are now set by build.rs instead. The linker argument can still
+  # only be set here, if a custom linker is needed.
 
-  # LLD (shipped with the Rust toolchain) is used as the default linker
-  "-C", "link-arg=-Tlink.x",
-
-  # if you run into problems with LLD switch to the GNU linker by commenting out
-  # this line
+  # By default, the LLD linker is used, which is shipped with the Rust
+  # toolchain. If you run into problems with LLD, you can switch to the
+  # GNU linker by uncommenting this line:
   # "-C", "linker=arm-none-eabi-ld",
 
-  # if you need to link to pre-compiled C libraries provided by a C toolchain
-  # use GCC as the linker by commenting out both lines above and then
-  # uncommenting the three lines below
+  # If you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by uncommenting the three lines below:
   # "-C", "linker=arm-none-eabi-gcc",
   # "-C", "link-arg=-Wl,-Tlink.x",
   # "-C", "link-arg=-nostartfiles",
 ]
 
 [build]
-# Pick ONE of these compilation targets
+# Pick ONE of these default compilation targets
 # target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+
 target = "thumbv7m-none-eabi"        # Cortex-M3
 # target = "thumbv7em-none-eabi"       # Cortex-M4 and Cortex-M7 (no FPU)

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,8 @@
 //! Cargo re-run the build script whenever `memory.x` is changed,
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
+//!
+//! The build script also sets the linker flags to tell it which link script to use.
 
 use std::env;
 use std::fs::File;
@@ -28,4 +30,14 @@ fn main() {
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
     println!("cargo:rerun-if-changed=memory.x");
+
+    // Specify linker arguments.
+
+    // `--nmagic` is required if memory section addresses are not aligned to 0x10000,
+    // for example the FLASH and RAM sections in your `memory.x`.
+    // See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+    println!("cargo:rustc-link-arg=--nmagic");
+
+    // Set the linker script to the one provided by cortex-m-rt.
+    println!("cargo:rustc-link-arg=-Tlink.x");
 }


### PR DESCRIPTION
It's easy to forget about the hidden `.cargo/config.toml` file, and setting the linker flags in build.rs also means they can be changed without requiring a rebuild of everything, they are more robust to running the build from a location where `.cargo/config.toml` isn't picked up, and they make it easier to support different linker arguments for different crates or binaries.

Thanks to @Dirbaio for the suggestion!