### PR TITLE
Add a user-defined HardFault handler to print ExceptionFrame in crash…

### DIFF
--- a/examples/crash.rs
+++ b/examples/crash.rs
@@ -82,14 +82,25 @@
 use panic_halt as _;
 
 use core::ptr;
+use core::fmt::Write;
 
-use cortex_m_rt::entry;
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+use cortex_m_semihosting::hio;
 
 #[entry]
 fn main() -> ! {
     unsafe {
         // read an address outside of the RAM region; this causes a HardFault exception
         ptr::read_volatile(0x2FFF_FFFF as *const u32);
+    }
+
+    loop {}
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    if let Ok(mut hstdout) = hio::hstdout() {
+        writeln!(hstdout, "{:#?}", ef).ok();
     }
 
     loop {}


### PR DESCRIPTION
The doc comment at [the top of crash.rs](https://github.com/rust-embedded/cortex-m-quickstart/blob/master/examples/crash.rs#L28-L41) makes it seem like the target hardware should print out the ExceptionFrame to the semihosting console on crash.

I was following along with the examples and noticed the target app doesn't print that bit of text out without this patch.