### PR TITLE
Update crates and adapt example code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,16 @@ name = "{{project-name}}"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-panic-halt = "0.2.0"
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
+panic-halt = "1.0.0"
 
 # Uncomment for the panic example.
 # panic-itm = "0.4.1"
 
 # Uncomment for the allocator example.
-# alloc-cortex-m = "0.4.0"
+# embedded-alloc = "0.6.0"
 
 # Uncomment for the device example.
 # Update `memory.x`, set target to `thumbv7em-none-eabihf` in `.cargo/config`,

--- a/examples/allocator.rs
+++ b/examples/allocator.rs
@@ -1,15 +1,14 @@
 //! How to use the heap and a dynamic memory allocator
 //!
-//! This example depends on the alloc-cortex-m crate so you'll have to add it to your Cargo.toml:
+//! This example depends on the embedded-alloc crate so you'll have to add it to your Cargo.toml:
 //!
 //! ``` text
 //! # or edit the Cargo.toml file manually
-//! $ cargo add alloc-cortex-m
+//! $ cargo add embedded-alloc
 //! ```
 //!
 //! ---
 
-#![feature(alloc_error_handler)]
 #![no_main]
 #![no_std]
 
@@ -17,40 +16,37 @@ extern crate alloc;
 use panic_halt as _;
 
 use self::alloc::vec;
-use core::alloc::Layout;
+use core::ptr::addr_of_mut;
 
-use alloc_cortex_m::CortexMHeap;
-use cortex_m::asm;
+// Linked-List First Fit Heap allocator (feature = "llff")
+use embedded_alloc::LlffHeap as Heap;
+// Two-Level Segregated Fit Heap allocator (feature = "tlsf")
+// use embedded_alloc::TlsfHeap as Heap;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{hprintln, debug};
 
 // this is the allocator the application will use
 #[global_allocator]
-static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
-
-const HEAP_SIZE: usize = 1024; // in bytes
+static HEAP: Heap = Heap::empty();
 
 #[entry]
 fn main() -> ! {
     // Initialize the allocator BEFORE you use it
-    unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
+    {
+        use core::mem::MaybeUninit;
+        const HEAP_SIZE: usize = 1024;
+        static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
+        unsafe { HEAP.init(addr_of_mut!(HEAP_MEM) as usize, HEAP_SIZE) }
+    }
 
     // Growable array allocated on the heap
     let xs = vec![0, 1, 2];
 
-    hprintln!("{:?}", xs).unwrap();
+    hprintln!("{:?}", xs);
 
     // exit QEMU
     // NOTE do not run this on hardware; it can corrupt OpenOCD state
     debug::exit(debug::EXIT_SUCCESS);
-
-    loop {}
-}
-
-// define what happens in an Out Of Memory (OOM) condition
-#[alloc_error_handler]
-fn alloc_error(_layout: Layout) -> ! {
-    asm::bkpt();
 
     loop {}
 }

--- a/examples/crash.rs
+++ b/examples/crash.rs
@@ -97,8 +97,8 @@ fn main() -> ! {
     loop {}
 }
 
-#[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+#[exception(trampoline = true)]
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     if let Ok(mut hstdout) = hio::hstdout() {
         writeln!(hstdout, "{:#?}", ef).ok();
     }

--- a/examples/device.rs
+++ b/examples/device.rs
@@ -58,5 +58,5 @@ fn main() -> ! {
 
 #[interrupt]
 fn EXTI0() {
-    hprint!(".").unwrap();
+    hprint!(".");
 }

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -33,5 +33,5 @@ fn main() -> ! {
 
 #[exception]
 fn SysTick() {
-    hprint!(".").unwrap();
+    hprint!(".");
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -10,7 +10,7 @@ use cortex_m_semihosting::{debug, hprintln};
 
 #[entry]
 fn main() -> ! {
-    hprintln!("Hello, world!").unwrap();
+    hprintln!("Hello, world!");
 
     // exit QEMU
     // NOTE do not run this on hardware; it can corrupt OpenOCD state


### PR DESCRIPTION
The allocator example is basically the same as [here](https://github.com/rust-embedded/embedded-alloc/blob/master/examples/global_alloc.rs).

The necessary change in the crash example is documented [here](https://docs.rs/cortex-m-rt/latest/cortex_m_rt/attr.exception.html#hardfault-handler).